### PR TITLE
DateCellEditor: Prevent display glitches when focussing DateTime widget

### DIFF
--- a/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/editor/DateCellEditor.java
+++ b/org.eclipse.nebula.widgets.nattable.core/src/org/eclipse/nebula/widgets/nattable/edit/editor/DateCellEditor.java
@@ -177,12 +177,16 @@ public class DateCellEditor extends AbstractCellEditor {
         this.dateTime = createEditorControl(parent);
         setCanonicalValue(originalCanonicalValue);
 
-        // this is necessary so the control gets the focus
-        // but this also causing some issues as focusing the DateTime control
-        // programmatically does some strange things with showing the editable
-        // data also it seems to be not possible to open the dropdown
-        // programmatically
-        this.dateTime.forceFocus();
+        // set focus asynchronously in order to prevent display glitches
+        // it seems to be not possible to open the dropdown programmatically
+        parent.getDisplay().asyncExec(new Runnable() {
+            @Override
+            public void run() {
+                if (! this.dateTime.isDisposed()) {
+                    this.dateTime.forceFocus();
+                }
+            }
+        });
 
         return this.dateTime;
     }


### PR DESCRIPTION
When using a `DateCellEditor` the underlying `DateTime` widget is being focussed on cell activation. This causes severe display glitches, e.g. only partially displayed widgets.

This pull request works around the problem by setting the focus per `Display#asyncExec` in a deferred way. Thus, the `DateTime` widget is focussed and yet correctly displayed.